### PR TITLE
Fix deprecation warning PHP 8.1

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,25 +4,24 @@ To change this license header, choose License Headers in Project Properties.
 To change this template file, choose Tools | Templates
 and open the template in the editor.
 -->
-
 <!-- see http://www.phpunit.de/wiki/Documentation -->
-<phpunit bootstrap="./vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="./vendor/autoload.php"
          colors="false"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
-         stopOnFailure="false">
-
-    <filter>
-        <whitelist>
-            <directory>./src</directory>
-        </whitelist>
-    </filter>
-    
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
-    
+         convertDeprecationsToExceptions="true"
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -122,7 +122,7 @@ class Uri implements UriInterface, CustomUriInterface
 
     public function getQuery()
     {
-        return http_build_query($this->query, null, "&", PHP_QUERY_RFC3986);
+        return http_build_query($this->query, "", "&", PHP_QUERY_RFC3986);
     }
 
     /**
@@ -149,13 +149,13 @@ class Uri implements UriInterface, CustomUriInterface
         return $this->getFromArray($this->query, $key);
     }
 
-    private function getFromArray($array, $key)
+    private function getFromArray($array, $key, $default = null)
     {
         if (isset($array[$key])) {
             return $array[$key];
         }
 
-        return null;
+        return $default;
     }
 
     private $fragment;
@@ -238,7 +238,7 @@ class Uri implements UriInterface, CustomUriInterface
         $this->username = $user;
         $this->password = rawurldecode($this->getFromArray($parsed, 'pass'));
         $this->path = preg_replace('~^//~', '', $this->getFromArray($parsed, 'path'));
-        $this->setQuery($this->getFromArray($parsed, 'query'));
+        $this->setQuery($this->getFromArray($parsed, 'query', ""));
         $this->fragment = $this->getFromArray($parsed, 'fragment');
     }
 


### PR DESCRIPTION
This PR fixes some deprecation warnings found on PHP Migration's [issue 41](https://github.com/byjg/migration/issues/41) 